### PR TITLE
chore: Pin action to v1

### DIFF
--- a/.github/workflows/back-ci.yml
+++ b/.github/workflows/back-ci.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
-      - uses: 47ng/actions-clever-cloud@master
+      - uses: 47ng/actions-clever-cloud@v1
         with:
           alias: delta-v-back-prod
         env:


### PR DESCRIPTION
There will soon be an update with breaking changes on the `master` branch of [`47ng/actions-clever-cloud`](https://github.com/47ng/actions-clever-cloud).

While those breaking changes concern features that you are not currently using (environment variables), it's better practice to have actions pinned to a particular version.